### PR TITLE
feat(ui): add landing page animation

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,22 +35,24 @@ const socialLinks = [
     <h1 id="home-title">Hello</h1>
     <p class="landing-name">Jay Yu</p>
     <nav class="landing-links landing-links--primary" aria-label="Primary pages">
-      {primaryLinks.map((link) => (
+      {primaryLinks.map((link, index) => (
         <a
           href={link.href}
           target={link.external ? '_blank' : undefined}
           rel={link.external ? 'noopener noreferrer' : undefined}
+          style={`--landing-item-index: ${index};`}
         >
           [{link.label}]
         </a>
       ))}
     </nav>
     <nav class="landing-links landing-links--social" aria-label="Social links">
-      {socialLinks.map((link) => (
+      {socialLinks.map((link, index) => (
         <a
           href={link.href}
           target={link.external ? '_blank' : undefined}
           rel={link.external ? 'noopener noreferrer' : undefined}
+          style={`--landing-item-index: ${index};`}
         >
           [{link.label}]
         </a>

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -47,6 +47,7 @@
   font-size: clamp(4.25rem, 12vw, 9.5rem);
   line-height: 0.86;
   letter-spacing: 0;
+  animation: landing-text-in 760ms cubic-bezier(0.16, 1, 0.3, 1) 90ms both;
 }
 
 .landing-name {
@@ -57,6 +58,7 @@
   font-size: clamp(1.65rem, 3.8vw, 3.2rem);
   font-weight: 700;
   line-height: 1;
+  animation: landing-text-in 700ms cubic-bezier(0.16, 1, 0.3, 1) 240ms both;
 }
 
 .landing-links {
@@ -75,6 +77,7 @@
   color: var(--color-text-muted);
   text-decoration: none;
   white-space: nowrap;
+  animation: landing-text-in 560ms cubic-bezier(0.16, 1, 0.3, 1) both;
   transition: color 160ms ease, transform 160ms ease;
 }
 
@@ -89,6 +92,10 @@
   justify-self: end;
 }
 
+.landing-links--primary a {
+  animation-delay: calc(420ms + (var(--landing-item-index, 0) * 70ms));
+}
+
 .landing-links--social {
   grid-row: 3;
   align-self: end;
@@ -97,6 +104,32 @@
   flex-wrap: nowrap;
   align-items: flex-end;
   gap: 10px;
+}
+
+.landing-links--social a {
+  animation-delay: calc(700ms + (var(--landing-item-index, 0) * 70ms));
+}
+
+@keyframes landing-text-in {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+    filter: blur(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landing-home h1,
+  .landing-name,
+  .landing-links a {
+    animation: none;
+  }
 }
 
 .dev-header,


### PR DESCRIPTION
  ## Summary
  - Adds a smooth staggered entrance animation for the landing page text.
  - Animates greeting texts, primary links, and social links in sequence.
  - Adds per-link animation delays using CSS custom properties.
  - Respects `prefers-reduced-motion` by disabling the animation for users who request reduced motion.

  ## Testing

  - Ran `npm run build`.
  - Verified desktop and mobile landing screenshots after the animation settles.
