### PR TITLE
docs(ui): update about page copy

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -21,25 +21,27 @@ import PageHeader from '../components/PageHeader.astro';
     </div>
     <div class="prose">
       <p>
-        Hey, I am Jay.
-        I study computer science at Purdue University and care about building systems that stay useful after the demo.
+        Hey, I'm Jay.
+        I study CS with a concentration in ML at Purdue University.
+        I love wildlife (beavers, anteaters, wombats, hyrax), reading modern Chinese literature, and playing badminton.
       </p>
       <p>
-        I like clean interfaces, strong feedback loops, reliable tests, and code that can be maintained by the next person who reads it.
+        I grew up in Luzhou, Sichuan, China, where I lived and studied until third grade before moving to the Bay Area in California.
+        I did middle school all the way through high school there, which meant growing up right at the seam between Eastern and Western culture, long enough in each place to belong to it, but always aware of the other one sitting just behind my shoulder.
+        That in-between vantage point turned out to be a gift.
+        It gave me two toolkits to reach for whenever I run into a problem: two ways of framing a question, two sets of instincts about what matters, and the habit of switching between them until one of them cracks the problem open.
       </p>
       <p>
-        Recent work includes model refinement, vision systems, real-time translation experiments, and LuntraHub, a student connection and tutor discovery platform.
+        Fast forward to now, and I'm someone who loves blending things that have no business going together just to see how they'd turn out.
+        I have a lot of hobbies: reading is one, modern Chinese history and Chinese poetry are another, badminton is another, and video games are another (top 1% in Valorant in 2024, top 1% in Fortnite in 2022, top 500 in PUBG Mobile in 2018) - though I'm not much of a gamer anymore.
+        Most of all, I love AI and startups.
+        I can go on and on about the newest papers optimizing attention mechanisms in transformers, the coolest RAG techniques, or the most exciting startup ideas out there.
+        Nine times out of ten, when I picture the future, I see myself working on a startup idea that keeps me thrilled to keep building.
+        I'm excited for what's coming, and I want to take the biggest risks on the coolest ideas that are yet to come.
       </p>
-      <h2>Operating principles</h2>
-      <ul>
-        <li>Prototype quickly, then simplify the system until the important parts are obvious.</li>
-        <li>Measure real behavior, not just local happy paths.</li>
-        <li>Use the smallest architecture that can stay reliable as the product grows.</li>
-        <li>Keep learning from research, production constraints, and users in the loop.</li>
-      </ul>
-      <h2>Now</h2>
       <p>
-        I am focused on school, LuntraHub, research-adjacent experiments, and publishing notes from the systems I am building.
+        If you want to see what I'm actually building, take a look around the rest of the site for my latest work at Luntraa.
+        And if you're curious to go deeper, check out my LinkedIn for technical progress and my X for technical discussions.
       </p>
     </div>
   </section>


### PR DESCRIPTION
  ## Summary
  - Replaces the generic About page text with a more personal biography.
  - Adds background on CS/ML focus, interests, upbringing, and current direction.
  - Removes the previous "Operating principles" and "Now" sections in favor of a single narrative profile.
  - Points readers toward the rest of the site, LinkedIn, and X for current work and technical updates.

  ## Testing
  - Ran `npm run build`.
