### PR TITLE
feat(landing): add landing page panels

### DIFF
--- a/src/components/SiteShell.astro
+++ b/src/components/SiteShell.astro
@@ -7,11 +7,12 @@ interface Props {
   title: string;
   description: string;
   image?: ImageMetadata;
+  bodyClass?: string;
   mainClass?: string;
   showFooter?: boolean;
 }
 
-const { title, description, image, mainClass, showFooter = true } = Astro.props as Props;
+const { title, description, image, bodyClass, mainClass, showFooter = true } = Astro.props as Props;
 ---
 
 <!doctype html>
@@ -20,7 +21,7 @@ const { title, description, image, mainClass, showFooter = true } = Astro.props 
     <BaseHead title={title} description={description} image={image} />
     <slot name="head" />
   </head>
-  <body>
+  <body class:list={[bodyClass]}>
     <div class="site-grid-bg" aria-hidden="true"></div>
     <main class:list={['use-utility-layout', 'site-main', mainClass]}>
       <slot />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -21,25 +21,27 @@ import PageHeader from '../components/PageHeader.astro';
     </div>
     <div class="prose">
       <p>
-        Hey, I am Jay.
-        I study computer science at Purdue University and care about building systems that stay useful after the demo.
+        Hey, I'm Jay.
+        I study CS with a concentration in ML at Purdue University.
+        I love wildlife (beavers, anteaters, wombats, hyrax), reading modern Chinese literature, and playing badminton.
       </p>
       <p>
-        I like clean interfaces, strong feedback loops, reliable tests, and code that can be maintained by the next person who reads it.
+        I grew up in Luzhou, Sichuan, China, where I lived and studied until third grade before moving to the Bay Area in California.
+        I did middle school all the way through high school there, which meant growing up right at the seam between Eastern and Western culture, long enough in each place to belong to it, but always aware of the other one sitting just behind my shoulder.
+        That in-between vantage point turned out to be a gift.
+        It gave me two toolkits to reach for whenever I run into a problem: two ways of framing a question, two sets of instincts about what matters, and the habit of switching between them until one of them cracks the problem open.
       </p>
       <p>
-        Recent work includes model refinement, vision systems, real-time translation experiments, and LuntraHub, a student connection and tutor discovery platform.
+        Fast forward to now, and I'm someone who loves blending things that have no business going together just to see how they'd turn out.
+        I have a lot of hobbies: reading is one, modern Chinese history and Chinese poetry are another, badminton is another, and video games are another (top 1% in Valorant in 2024, top 1% in Fortnite in 2022, top 500 in PUBG Mobile in 2018) - though I'm not much of a gamer anymore.
+        Most of all, I love AI and startups.
+        I can go on and on about the newest papers optimizing attention mechanisms in transformers, the coolest RAG techniques, or the most exciting startup ideas out there.
+        Nine times out of ten, when I picture the future, I see myself working on a startup idea that keeps me thrilled to keep building.
+        I'm excited for what's coming, and I want to take the biggest risks on the coolest ideas that are yet to come.
       </p>
-      <h2>Operating principles</h2>
-      <ul>
-        <li>Prototype quickly, then simplify the system until the important parts are obvious.</li>
-        <li>Measure real behavior, not just local happy paths.</li>
-        <li>Use the smallest architecture that can stay reliable as the product grows.</li>
-        <li>Keep learning from research, production constraints, and users in the loop.</li>
-      </ul>
-      <h2>Now</h2>
       <p>
-        I am focused on school, LuntraHub, research-adjacent experiments, and publishing notes from the systems I am building.
+        If you want to see what I'm actually building, take a look around the rest of the site for my latest work at Luntraa.
+        And if you're curious to go deeper, check out my LinkedIn for technical progress and my X for technical discussions.
       </p>
     </div>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,9 +14,21 @@ const socialLinks = [
   { label: 'email', href: 'mailto:jialey2025@gmail.com' },
   { label: 'x', href: 'https://x.com/pepps233', external: true },
 ];
+
+const currentlyItems = [
+  { label: 'working on', text: 'diffex ai', href: 'https://diffex.ai/', external: true },
+  { label: 'cool reads', text: 'Agent Loops', href: 'https://x.com/0xCodez/status/2064374643729773029', external: true },
+  { label: 'last book', text: 'To Live, Yu Hua', href: '/blog/' },
+];
 ---
 
-<SiteShell title={SITE_TITLE} description={SITE_DESCRIPTION} mainClass="landing-main" showFooter={false}>
+<SiteShell
+  title={SITE_TITLE}
+  description={SITE_DESCRIPTION}
+  bodyClass="landing-page"
+  mainClass="landing-main"
+  showFooter={false}
+>
   <Fragment slot="head">
     <script type="application/ld+json" set:html={JSON.stringify({
       '@context': 'https://schema.org',
@@ -46,6 +58,20 @@ const socialLinks = [
         </a>
       ))}
     </nav>
+    <div class="landing-currently" aria-label="Current notes">
+      {currentlyItems.map((item, index) => (
+        <p style={`--landing-item-index: ${index};`}>
+          <span>[{item.label}]:</span>
+          <a
+            href={item.href}
+            target={item.external ? '_blank' : undefined}
+            rel={item.external ? 'noopener noreferrer' : undefined}
+          >
+            {item.text}
+          </a>
+        </p>
+      ))}
+    </div>
     <nav class="landing-links landing-links--social" aria-label="Social links">
       {socialLinks.map((link, index) => (
         <a

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -62,6 +62,8 @@ html {
 	overflow-x: hidden;
 	overflow-x: clip;
 	overscroll-behavior: none;
+	scrollbar-width: none;
+	-ms-overflow-style: none;
 }
 
 body {
@@ -82,6 +84,29 @@ body {
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	scrollbar-width: none;
+	-ms-overflow-style: none;
+}
+
+html::-webkit-scrollbar,
+body::-webkit-scrollbar {
+	display: none;
+	width: 0;
+	height: 0;
+}
+
+body.landing-page {
+	height: 100vh;
+	height: 100dvh;
+	overflow: hidden;
+}
+
+@media (max-width: 720px) {
+	body.landing-page {
+		position: fixed;
+		inset: 0;
+		width: 100%;
+	}
 }
 
 main:not(.use-utility-layout) {

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -18,6 +18,8 @@
   height: 100vh;
   height: 100dvh;
   min-height: 100vh;
+  min-height: 100dvh;
+  max-height: 100dvh;
   position: relative;
   display: grid;
   place-items: center;
@@ -31,6 +33,7 @@
 .landing-home {
   width: min(1320px, calc(100% - 96px));
   min-height: min(620px, calc(100vh - 160px));
+  min-height: min(620px, calc(100dvh - 160px));
   position: relative;
   display: grid;
   grid-template-columns: minmax(0, auto) minmax(320px, 1fr);
@@ -96,6 +99,30 @@
   animation-delay: calc(420ms + (var(--landing-item-index, 0) * 70ms));
 }
 
+.landing-currently {
+  grid-column: 2;
+  grid-row: 3;
+  justify-self: end;
+  align-self: start;
+  display: grid;
+  gap: 8px;
+  max-width: min(430px, 100%);
+  margin-top: clamp(16px, 3vh, 34px);
+  font-size: clamp(0.82rem, 1.1vw, 0.94rem);
+  line-height: 1.25;
+  text-align: right;
+}
+
+.landing-currently p {
+  margin: 0;
+  animation: landing-text-in 560ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: calc(620ms + (var(--landing-item-index, 0) * 70ms));
+}
+
+.landing-currently a {
+  text-decoration: none;
+}
+
 .landing-links--social {
   grid-row: 3;
   align-self: end;
@@ -127,7 +154,8 @@
 @media (prefers-reduced-motion: reduce) {
   .landing-home h1,
   .landing-name,
-  .landing-links a {
+  .landing-links a,
+  .landing-currently p {
     animation: none;
   }
 }
@@ -1065,6 +1093,7 @@
   .landing-home {
     width: min(980px, calc(100% - 40px));
     min-height: calc(100vh - 96px);
+    min-height: calc(100dvh - 96px);
     margin-top: clamp(24px, 6vh, 48px);
     grid-template-columns: 1fr;
     grid-template-rows: auto auto;
@@ -1100,8 +1129,28 @@
     gap: 10px;
   }
 
+  .landing-currently {
+    grid-column: 1;
+    grid-row: 3;
+    justify-self: start;
+    align-self: start;
+    max-width: min(310px, calc(100vw - 40px));
+    margin-top: clamp(68px, 13vh, 128px);
+    text-align: left;
+  }
+
   .landing-links--social {
     bottom: clamp(72px, 12vh, 112px);
+  }
+
+  @media (max-height: 620px) {
+    .landing-currently {
+      margin-top: clamp(44px, 8vh, 58px);
+    }
+
+    .landing-links--primary {
+      bottom: clamp(210px, 38vh, 230px);
+    }
   }
 
   .dev-footer__grid,


### PR DESCRIPTION
  ## Summary

  - Adds a new landing-page section for current work, cool reading, and last book.
  - Links `diffex ai` to `https://diffex.ai/`, `Agent Loops` to the requested X post, and `To Live, Yu Hua` to the blog page.
  - Positions the new section below the primary landing links on desktop and below the welcome text on mobile.
  - Adds landing-page viewport locking to prevent stray scroll overflow.

  ## Testing

  - Ran `npm run build`.
  - Verified desktop and mobile landing layouts with screenshots.
