### PR TITLE
Fix mobile layouts and blog share placement

### DIFF
--- a/src/components/ui/meta/PostMeta.astro
+++ b/src/components/ui/meta/PostMeta.astro
@@ -2,14 +2,17 @@
 import { author } from '../../../data/author';
 import FormattedDate from '../../FormattedDate.astro';
 import { slugifyTag as slugify } from '../../../lib/slug';
+import ShareButtons from '../share/ShareButtons.astro';
 
 interface Props {
   pubDate: Date;
   readingTimeMin: number;
   authorName?: string;
+  title: string;
+  url: string;
 }
 
-const { pubDate, readingTimeMin, authorName } = Astro.props as Props;
+const { pubDate, readingTimeMin, authorName, title, url } = Astro.props as Props;
 const displayName = authorName || author.name;
 ---
 
@@ -27,4 +30,5 @@ const displayName = authorName || author.name;
     <dt>Read</dt>
     <dd>{readingTimeMin} min</dd>
   </dl>
+  <ShareButtons title={title} url={url} />
 </aside>

--- a/src/components/ui/share/ShareButtons.astro
+++ b/src/components/ui/share/ShareButtons.astro
@@ -12,10 +12,10 @@ import xIcon from '../../../assets/icons/x-blog-post-share-icon.svg?raw';
 import liIcon from '../../../assets/icons/linkedin-blog-post-shareicon.svg?raw';
 ---
 
-<div class="module-card article-meta-card">
+<div class="article-meta-card__share">
   <span class="module-label">Share</span>
   <div class="sw-share">
-    <a href={xUrl} target="_blank" rel="noopener noreferrer" class="sw-share-btn" aria-label="Share on X" set:html={xIcon} />
     <a href={liUrl} target="_blank" rel="noopener noreferrer" class="sw-share-btn" aria-label="Share on LinkedIn" set:html={liIcon} />
+    <a href={xUrl} target="_blank" rel="noopener noreferrer" class="sw-share-btn" aria-label="Share on X" set:html={xIcon} />
   </div>
 </div>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -3,7 +3,6 @@ import { Image } from 'astro:assets';
 import type { CollectionEntry } from 'astro:content';
 import SiteShell from '../components/SiteShell.astro';
 import PostMeta from '../components/ui/meta/PostMeta.astro';
-import ShareButtons from '../components/ui/share/ShareButtons.astro';
 import PostNav from '../components/ui/nav/PostNav.astro';
 import { slugifyTag } from '../lib/slug';
 
@@ -90,8 +89,13 @@ const authorName = Astro.props.author || 'Jay Yu';
 
     <div class="article-grid">
       <div class="article-aside">
-        <PostMeta pubDate={pubDate} readingTimeMin={readingTimeMin} authorName={authorName} />
-        <ShareButtons title={title} url={Astro.url.toString()} />
+        <PostMeta
+          pubDate={pubDate}
+          readingTimeMin={readingTimeMin}
+          authorName={authorName}
+          title={title}
+          url={Astro.url.toString()}
+        />
       </div>
       <div class="prose article-prose">
         <slot />

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -9,5 +9,5 @@ import Projects from "../components/sections/Projects.astro";
     title="Projects"
     description="Build notes and shipped experiments."
   />
-  <Projects title="Project log" description="Selected work grouped away from the landing page." />
+  <Projects title="Project log" />
 </SiteShell>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -9,5 +9,5 @@ import Projects from "../components/sections/Projects.astro";
     title="Projects"
     description="Build notes and shipped experiments."
   />
-  <Projects title="Project log" description="Selected work grouped away from the landing page." />
+  <Projects title="Project log" />
 </SiteShell>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -101,14 +101,6 @@ body.landing-page {
 	overflow: hidden;
 }
 
-@media (max-width: 720px) {
-	body.landing-page {
-		position: fixed;
-		inset: 0;
-		width: 100%;
-	}
-}
-
 main:not(.use-utility-layout) {
 	width: 1280px;
 	max-width: calc(100% - 2rem);

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -724,6 +724,13 @@
   gap: 8px;
 }
 
+.article-meta-card__share {
+  display: grid;
+  gap: 8px;
+  padding-top: 10px;
+  border-top: 1px solid var(--color-border-light);
+}
+
 .sw-share-btn {
   display: inline-flex;
   width: 38px;
@@ -1085,24 +1092,28 @@
   }
 
   .landing-main {
-    padding-inline: 0;
-    align-items: start;
+    align-items: stretch;
+    min-height: 100svh;
+    height: 100svh;
+    max-height: none;
+    padding: clamp(22px, 6vh, 42px) 0;
+    overflow-y: auto;
     background-position: center;
   }
 
   .landing-home {
     width: min(980px, calc(100% - 40px));
-    min-height: calc(100vh - 96px);
-    min-height: calc(100dvh - 96px);
-    margin-top: clamp(24px, 6vh, 48px);
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto;
-    gap: 12px;
+    min-height: calc(100svh - clamp(44px, 12vh, 84px));
+    margin: 0 auto;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto auto minmax(28px, 1fr) auto minmax(44px, 0.8fr) auto;
+    gap: clamp(8px, 2vh, 14px);
   }
 
   .landing-home h1 {
     grid-column: 1;
     grid-row: 1;
+    font-size: clamp(4rem, 20vw, 6rem);
   }
 
   .landing-name {
@@ -1112,19 +1123,16 @@
   }
 
   .landing-links {
-    position: fixed;
-    grid-column: auto;
-    grid-row: auto;
-    right: max(20px, calc(100vw - 370px));
-    flex-direction: column;
-    flex-wrap: nowrap;
-    align-items: flex-end;
-    gap: 6px;
-    max-width: calc(100vw - 56px);
+    position: static;
+    grid-column: 1;
+    flex-wrap: wrap;
+    max-width: 100%;
   }
 
   .landing-links--primary {
-    bottom: clamp(260px, 35vh, 330px);
+    grid-row: 4;
+    justify-self: start;
+    justify-content: flex-start;
     flex-direction: row;
     gap: 10px;
   }
@@ -1133,23 +1141,29 @@
     grid-column: 1;
     grid-row: 3;
     justify-self: start;
-    align-self: start;
-    max-width: min(310px, calc(100vw - 40px));
-    margin-top: clamp(68px, 13vh, 128px);
+    align-self: end;
+    max-width: min(310px, 100%);
+    margin-top: 0;
     text-align: left;
   }
 
   .landing-links--social {
-    bottom: clamp(72px, 12vh, 112px);
+    grid-row: 6;
+    justify-self: end;
+    align-self: end;
+    align-items: flex-end;
+    justify-content: flex-end;
+    flex-direction: column;
   }
 
   @media (max-height: 620px) {
-    .landing-currently {
-      margin-top: clamp(44px, 8vh, 58px);
+    .landing-main {
+      height: auto;
+      min-height: 100svh;
     }
 
-    .landing-links--primary {
-      bottom: clamp(210px, 38vh, 230px);
+    .landing-home {
+      min-height: 560px;
     }
   }
 
@@ -1170,19 +1184,19 @@
     max-width: calc(100vw - 32px);
   }
 
-  .project-card h3,
-  .project-card p,
-  .project-card li,
   .section-copy {
     max-width: calc(100vw - 72px);
   }
 
-  .project-card ul {
-    padding-left: 0;
+  .project-card h3,
+  .project-card p,
+  .project-card ul,
+  .project-card li {
+    max-width: 100%;
   }
 
-  .project-card li {
-    max-width: 28ch;
+  .project-card ul {
+    padding-left: 1.1rem;
   }
 
   .module-header {


### PR DESCRIPTION
### Motivation
- Fix mobile landing-page layout and viewport-locking so link groups align consistently on small screens.
- Let project cards use the full card width on mobile so descriptions and lists no longer wrap prematurely.
- Consolidate blog sharing into the post metadata card and simplify share buttons to LinkedIn then X for a tighter inline UI.

### Description
- Removed mobile-only fixed body positioning in `src/styles/global.css` and reworked mobile landing layout rules in `src/styles/utilities.css` to use in-flow grid placement, `svh`-based sizing, and `overflow-y: auto` for the landing area.
- Adjusted `.landing-home` grid rows, `.landing-links` placement, and heading sizing to improve spacing and alignment on narrow screens in `src/styles/utilities.css`.
- Relaxed project-card text/list constraints so titles, paragraphs and list items can occupy the full card width, and removed the duplicated projects tagline from `src/pages/projects.astro` and `src/pages/portfolio.astro` by omitting the redundant `description` prop.
- Moved share UI into the post metadata component by adding `title` and `url` props to `src/components/ui/meta/PostMeta.astro` and rendering `ShareButtons` there, and simplified `src/components/ui/share/ShareButtons.astro` to render an inline metadata-style share block with LinkedIn first then X; added `.article-meta-card__share` styles to `src/styles/utilities.css`.

### Testing
- Ran `npm run build` to validate the site builds and static pages are generated, which completed successfully.
- Ran `git diff --check` to ensure no whitespace/patch issues and the repository shows the expected file changes with no reported errors.
- Attempted automated mobile screenshots via `npx playwright screenshot ...` to verify visual results, but the headless Chromium could not launch in this environment due to a missing system library (`libatk-1.0.so.0`), so screenshots could not be captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3af869f8b08331a24f49839867e2df)