### PR TITLE
fix(ui): align mobile landing links

### DIFF
--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -1131,10 +1131,12 @@
 
   .landing-links--primary {
     grid-row: 4;
-    justify-self: start;
-    justify-content: flex-start;
+    width: 100%;
+    justify-self: stretch;
+    justify-content: flex-end;
     flex-direction: row;
     gap: 10px;
+    text-align: right;
   }
 
   .landing-currently {


### PR DESCRIPTION
  ## Summary

  - Right-aligns the mobile landing page `[about] [blog] [projects]` navigation.
  - Keeps the links stacked horizontally on one row.
  - Makes the nav span the mobile content width so right alignment does not rely on shrink-wrapped layout.

  ## Testing

  - Ran `npm run build`.
  - Verified the mobile landing layout with screenshots.
