### PR TITLE
fix(ui): tighten mobile nav stack

### DIFF
--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -1130,12 +1130,14 @@
   }
 
   .landing-links--primary {
-    grid-row: 4;
+    grid-row: 5;
     width: 100%;
+    align-self: end;
     justify-self: stretch;
     justify-content: flex-end;
     flex-direction: row;
     gap: 10px;
+    margin-bottom: calc(10px - clamp(8px, 2vh, 14px));
     text-align: right;
   }
 


### PR DESCRIPTION
  ## Summary

  - Moves the mobile `[about] [blog] [projects]` row into the lower landing-page link cluster.
  - Keeps the primary links horizontal and right-aligned.
  - Tightens the spacing so the primary links sit directly above `[linkedin]`.

  ## Testing

  - Ran `npm run build`.
  - Verified the mobile landing layout with screenshots.