### PR TITLE
fix(landing): preload background before text animation

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,6 +30,48 @@ const currentlyItems = [
   showFooter={false}
 >
   <Fragment slot="head">
+    <link rel="preload" as="image" href="/images/clouds.png" type="image/png" fetchpriority="high" />
+    <style is:inline>
+      html.landing-bg-pending .landing-home h1,
+      html.landing-bg-pending .landing-name,
+      html.landing-bg-pending .landing-links a,
+      html.landing-bg-pending .landing-currently p {
+        opacity: 0;
+        transform: translateY(14px);
+        filter: blur(4px);
+        animation: none;
+      }
+    </style>
+    <script is:inline>
+      (() => {
+        const root = document.documentElement;
+        const backgroundImage = '/images/clouds.png';
+        const reveal = () => {
+          root.classList.remove('landing-bg-pending');
+          root.classList.add('landing-bg-loaded');
+        };
+
+        root.classList.add('landing-bg-pending');
+
+        const image = new Image();
+        image.decoding = 'async';
+        image.fetchPriority = 'high';
+        image.onload = () => {
+          if (typeof image.decode === 'function') {
+            image.decode().then(reveal, reveal);
+            return;
+          }
+
+          reveal();
+        };
+        image.onerror = reveal;
+        image.src = backgroundImage;
+
+        if (image.complete) {
+          image.onload();
+        }
+      })();
+    </script>
     <script type="application/ld+json" set:html={JSON.stringify({
       '@context': 'https://schema.org',
       '@type': 'Person',


### PR DESCRIPTION
## Summary
- Preloads `/images/clouds.png` with high fetch priority so the browser discovers the landing background from HTML instead of waiting for CSS discovery.
- Keeps the same background asset and quality.
- Holds the landing text in a pending state until the background image has loaded and decoded, then lets the existing popup animations run.

## Root Cause
The landing background was only referenced from CSS, so the browser could discover the large image later in the page load.
The text animations started immediately on first paint, which let text appear before the background arrived on slower connections.

## Validation
- Reproduced under throttled Chrome: the heading was already mid-animation while `clouds.png` only had `requestWillBeSent`.
- Verified after the fix under throttled Chrome: the image request is `High` priority with a parser initiator, and text remains at opacity `0` until `landing-bg-loaded`.
- Checked normal desktop and mobile screenshots.
- Ran `npm run build`.