### PR TITLE
feat(projects): redesign project showcase

### DIFF
--- a/src/components/projects/LiquidProjectMark.astro
+++ b/src/components/projects/LiquidProjectMark.astro
@@ -1,0 +1,380 @@
+---
+interface Props {
+  name: string;
+  symbol: string;
+  colors: readonly [string, string, string];
+  seed: number;
+}
+
+const { name, symbol, colors, seed } = Astro.props;
+---
+
+<div
+  class="liquid-mark"
+  data-liquid-mark
+  data-seed={seed}
+  style={`--liquid-a: ${colors[0]}; --liquid-b: ${colors[1]}; --liquid-c: ${colors[2]};`}
+  aria-hidden="true"
+>
+  <div class="liquid-mark__wash"></div>
+  <div class="liquid-mark__blob liquid-mark__blob--one" data-liquid-blob data-x="24" data-y="37"></div>
+  <div class="liquid-mark__blob liquid-mark__blob--two" data-liquid-blob data-x="52" data-y="62"></div>
+  <div class="liquid-mark__blob liquid-mark__blob--three" data-liquid-blob data-x="78" data-y="34"></div>
+  <div class="liquid-mark__blob liquid-mark__blob--four" data-liquid-blob data-x="76" data-y="76"></div>
+
+  <svg class="liquid-mark__symbol" viewBox="0 0 96 96" role="presentation">
+    {symbol === "mendr" && (
+      <>
+        <path d="M20 63V35l14 17 14-22 14 22 14-17v28" />
+        <path class="liquid-mark__detail" d="m60 65 7 7 13-17" />
+      </>
+    )}
+    {symbol === "graph" && (
+      <>
+        <path d="m24 63 21-29 27 12M24 63l27 9 21-26M45 34l6 38" />
+        <circle cx="24" cy="63" r="6" />
+        <circle cx="45" cy="34" r="6" />
+        <circle cx="72" cy="46" r="6" />
+        <circle cx="51" cy="72" r="6" />
+      </>
+    )}
+    {symbol === "spiral" && (
+      <path d="M73 49c0 14-11 25-25 25S23 63 23 49s11-25 25-25c11 0 20 8 20 19 0 10-8 18-18 18s-17-7-17-16c0-7 6-13 13-13 6 0 11 5 11 11 0 5-4 9-9 9-4 0-7-3-7-7" />
+    )}
+    {symbol === "embed" && (
+      <>
+        <path d="M28 24h31a9 9 0 0 1 9 9v39H37a9 9 0 0 1-9-9V24Z" />
+        <path class="liquid-mark__detail" d="M39 39h18M39 50h18M39 61h11" />
+        <path d="m55 72 13-13" />
+      </>
+    )}
+    {symbol === "overlay" && (
+      <>
+        <rect x="21" y="30" width="43" height="43" rx="10" />
+        <rect x="34" y="20" width="41" height="41" rx="10" />
+        <path class="liquid-mark__detail" d="M55 31v19M45.5 40.5h19" />
+      </>
+    )}
+    {symbol === "attendance" && (
+      <>
+        <path d="M22 26v44M31 26v44M43 26v44M57 26v44M66 26v44M75 26v44" />
+        <path class="liquid-mark__detail" d="m47 57 8 8 17-20" />
+      </>
+    )}
+    {symbol === "asl" && (
+      <>
+        <path d="M33 49V30a6 6 0 0 1 12 0v16-22a6 6 0 0 1 12 0v22-15a6 6 0 0 1 12 0v22-12a6 6 0 0 1 12 0v18c0 17-12 27-29 27-11 0-20-5-25-14L16 54a7 7 0 0 1 11-8l6 3Z" />
+        <path class="liquid-mark__detail" d="M45 46v7M57 46v7M69 46v7" />
+      </>
+    )}
+    {symbol === "people" && (
+      <>
+        <circle cx="48" cy="34" r="13" />
+        <path d="M24 74c2-15 10-23 24-23s22 8 24 23H24Z" />
+        <path class="liquid-mark__detail" d="M66 32h15M73.5 24.5v15" />
+      </>
+    )}
+  </svg>
+
+  <span class="liquid-mark__label">{name}</span>
+</div>
+
+<script>
+  const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+  const marks = Array.from(document.querySelectorAll("[data-liquid-mark]"));
+
+  const markStates = marks.map((mark) => {
+    const seed = Number(mark.getAttribute("data-seed")) || 1;
+    const blobs = Array.from(mark.querySelectorAll("[data-liquid-blob]")).map((blob, index) => ({
+      element: blob,
+      x: Number(blob.getAttribute("data-x")),
+      y: Number(blob.getAttribute("data-y")),
+      phase: seed * 0.79 + index * 1.63,
+      speed: 0.00022 + index * 0.000035,
+      dx: 0,
+      dy: 0,
+      scaleX: 1,
+      scaleY: 1,
+    }));
+
+    return {
+      mark,
+      blobs,
+      pointer: { x: 0, y: 0, active: false },
+      visible: true,
+    };
+  });
+
+  markStates.forEach((state) => {
+    state.mark.addEventListener("pointermove", (event) => {
+      const rect = state.mark.getBoundingClientRect();
+      state.pointer.x = event.clientX - rect.left;
+      state.pointer.y = event.clientY - rect.top;
+      state.pointer.active = true;
+    }, { passive: true });
+
+    state.mark.addEventListener("pointerleave", () => {
+      state.pointer.active = false;
+    });
+  });
+
+  if ("IntersectionObserver" in window) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        const state = markStates.find((candidate) => candidate.mark === entry.target);
+        if (state) state.visible = entry.isIntersecting;
+      });
+    }, { rootMargin: "120px" });
+
+    markStates.forEach((state) => observer.observe(state.mark));
+  }
+
+  let animationFrame = 0;
+
+  const renderLiquidMarks = (time) => {
+    if (prefersReducedMotion.matches) {
+      animationFrame = 0;
+      return;
+    }
+
+    markStates.forEach((state) => {
+      if (!state.visible) return;
+
+      const rect = state.mark.getBoundingClientRect();
+
+      state.blobs.forEach((blob, index) => {
+        const idleX = Math.sin(time * blob.speed + blob.phase) * (9 + index * 1.5);
+        const idleY = Math.cos(time * blob.speed * 0.81 + blob.phase) * (7 + index);
+        let pushX = 0;
+        let pushY = 0;
+        let squeeze = 0;
+
+        if (state.pointer.active) {
+          const centerX = rect.width * blob.x / 100 + idleX;
+          const centerY = rect.height * blob.y / 100 + idleY;
+          const deltaX = centerX - state.pointer.x;
+          const deltaY = centerY - state.pointer.y;
+          const distance = Math.max(Math.hypot(deltaX, deltaY), 1);
+          const reach = Math.min(rect.width, rect.height) * 0.7;
+          const force = Math.max(0, 1 - distance / reach);
+
+          pushX = deltaX / distance * force * 34;
+          pushY = deltaY / distance * force * 28;
+          squeeze = force * 0.2;
+        }
+
+        blob.dx += (idleX + pushX - blob.dx) * 0.1;
+        blob.dy += (idleY + pushY - blob.dy) * 0.1;
+        blob.scaleX += (1 + squeeze - blob.scaleX) * 0.1;
+        blob.scaleY += (1 - squeeze * 0.45 - blob.scaleY) * 0.1;
+
+        blob.element.style.setProperty("--liquid-dx", `${blob.dx.toFixed(2)}px`);
+        blob.element.style.setProperty("--liquid-dy", `${blob.dy.toFixed(2)}px`);
+        blob.element.style.setProperty("--liquid-scale-x", blob.scaleX.toFixed(3));
+        blob.element.style.setProperty("--liquid-scale-y", blob.scaleY.toFixed(3));
+      });
+    });
+
+    animationFrame = window.requestAnimationFrame(renderLiquidMarks);
+  };
+
+  const startLiquidMotion = () => {
+    if (!prefersReducedMotion.matches && animationFrame === 0) {
+      animationFrame = window.requestAnimationFrame(renderLiquidMarks);
+    }
+  };
+
+  prefersReducedMotion.addEventListener("change", startLiquidMotion);
+  startLiquidMotion();
+</script>
+
+<style>
+  .liquid-mark {
+    position: relative;
+    isolation: isolate;
+    height: clamp(138px, 17vw, 178px);
+    margin-top: 16px;
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--liquid-b) 26%, var(--color-border-light));
+    border-radius: 12px;
+    background:
+      radial-gradient(circle at 16% 10%, color-mix(in srgb, var(--liquid-a) 17%, transparent), transparent 31%),
+      radial-gradient(circle at 84% 88%, color-mix(in srgb, var(--liquid-c) 18%, transparent), transparent 34%),
+      color-mix(in srgb, var(--color-bg-primary) 92%, var(--liquid-b));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+    contain: layout paint;
+  }
+
+  .liquid-mark::before {
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 180 180' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.95' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.22'/%3E%3C/svg%3E");
+    content: "";
+    opacity: 0.1;
+    pointer-events: none;
+    mix-blend-mode: soft-light;
+  }
+
+  .liquid-mark__wash {
+    position: absolute;
+    inset: 13% 20%;
+    z-index: -1;
+    border-radius: 50%;
+    background: var(--liquid-b);
+    opacity: 0.25;
+    filter: blur(38px);
+  }
+
+  .liquid-mark__blob {
+    --liquid-dx: 0px;
+    --liquid-dy: 0px;
+    --liquid-scale-x: 1;
+    --liquid-scale-y: 1;
+    position: absolute;
+    will-change: transform, border-radius;
+    transform: translate3d(var(--liquid-dx), var(--liquid-dy), 0) scale(var(--liquid-scale-x), var(--liquid-scale-y));
+    filter: saturate(1.18);
+    opacity: 0.88;
+    mix-blend-mode: multiply;
+    animation: liquid-morph 8s ease-in-out infinite alternate;
+  }
+
+  .liquid-mark__blob--one {
+    top: 8%;
+    left: 5%;
+    width: 42%;
+    aspect-ratio: 1.28;
+    border-radius: 58% 42% 48% 52% / 43% 59% 41% 57%;
+    background: linear-gradient(135deg, var(--liquid-a), color-mix(in srgb, var(--liquid-a) 58%, white));
+  }
+
+  .liquid-mark__blob--two {
+    top: 30%;
+    left: 32%;
+    width: 39%;
+    aspect-ratio: 1.12;
+    border-radius: 47% 53% 63% 37% / 61% 43% 57% 39%;
+    background: linear-gradient(145deg, var(--liquid-b), color-mix(in srgb, var(--liquid-c) 26%, var(--liquid-b)));
+    animation-delay: -2.7s;
+  }
+
+  .liquid-mark__blob--three {
+    top: 3%;
+    right: 5%;
+    width: 31%;
+    aspect-ratio: 0.94;
+    border-radius: 62% 38% 52% 48% / 48% 62% 38% 52%;
+    background: linear-gradient(155deg, color-mix(in srgb, var(--liquid-c) 72%, white), var(--liquid-c));
+    animation-delay: -5.2s;
+  }
+
+  .liquid-mark__blob--four {
+    right: 8%;
+    bottom: -16%;
+    width: 42%;
+    aspect-ratio: 1.24;
+    border-radius: 39% 61% 48% 52% / 58% 37% 63% 42%;
+    background: linear-gradient(135deg, color-mix(in srgb, var(--liquid-a) 30%, var(--liquid-c)), var(--liquid-c));
+    animation-delay: -4s;
+  }
+
+  .liquid-mark__symbol {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    z-index: 3;
+    width: clamp(68px, 8vw, 84px);
+    height: clamp(68px, 8vw, 84px);
+    padding: 15px;
+    overflow: visible;
+    border: 1px solid rgba(255, 255, 255, 0.52);
+    border-radius: 28px;
+    background: rgba(255, 255, 255, 0.32);
+    color: rgba(13, 18, 28, 0.82);
+    box-shadow:
+      0 12px 32px rgba(22, 24, 35, 0.12),
+      inset 0 1px 0 rgba(255, 255, 255, 0.72);
+    transform: translate(-50%, -50%) rotate(-3deg);
+    backdrop-filter: blur(14px) saturate(1.2);
+    -webkit-backdrop-filter: blur(14px) saturate(1.2);
+    transition: transform 280ms cubic-bezier(0.2, 0.8, 0.2, 1);
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 5.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .liquid-mark:hover .liquid-mark__symbol {
+    transform: translate(-50%, -50%) rotate(2deg) scale(1.04);
+  }
+
+  .liquid-mark__detail {
+    stroke: rgba(255, 255, 255, 0.92);
+    stroke-width: 5;
+  }
+
+  .liquid-mark__label {
+    position: absolute;
+    right: 11px;
+    bottom: 9px;
+    z-index: 4;
+    max-width: calc(100% - 22px);
+    overflow: hidden;
+    color: rgba(16, 21, 30, 0.72);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  @keyframes liquid-morph {
+    0% {
+      border-radius: 58% 42% 48% 52% / 43% 59% 41% 57%;
+    }
+    50% {
+      border-radius: 41% 59% 38% 62% / 58% 40% 60% 42%;
+    }
+    100% {
+      border-radius: 53% 47% 61% 39% / 36% 56% 44% 64%;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .liquid-mark__blob {
+      animation: none;
+      will-change: auto;
+    }
+
+    .liquid-mark__symbol {
+      transition: none;
+    }
+  }
+
+  :global([data-theme="dark"]) .liquid-mark {
+    border-color: color-mix(in srgb, var(--liquid-b) 36%, transparent);
+    background:
+      radial-gradient(circle at 16% 10%, color-mix(in srgb, var(--liquid-a) 24%, transparent), transparent 31%),
+      radial-gradient(circle at 84% 88%, color-mix(in srgb, var(--liquid-c) 24%, transparent), transparent 34%),
+      #12141a;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+
+  :global([data-theme="dark"]) .liquid-mark__blob {
+    opacity: 0.9;
+    mix-blend-mode: screen;
+  }
+
+  :global([data-theme="dark"]) .liquid-mark__symbol {
+    border-color: rgba(255, 255, 255, 0.22);
+    background: rgba(15, 18, 27, 0.38);
+    color: rgba(255, 255, 255, 0.9);
+  }
+
+  :global([data-theme="dark"]) .liquid-mark__label {
+    color: rgba(255, 255, 255, 0.64);
+  }
+</style>

--- a/src/components/sections/Projects.astro
+++ b/src/components/sections/Projects.astro
@@ -1,5 +1,6 @@
 ---
 import { projects } from "../../data/projects";
+import LiquidProjectMark from "../projects/LiquidProjectMark.astro";
 
 const monthRank = new Map(
   [
@@ -42,22 +43,14 @@ const projectItems = projects.slice().sort((a, b) => projectDateRank(b.date) - p
         <div class="project-card__topline">
           <span>{project.date || "Recent"}</span>
         </div>
-        <div class="project-card__icon" aria-hidden="true" set:html={project.icon} />
+        <LiquidProjectMark name={project.title} {...project.mark} />
         <h3>{project.title}</h3>
         <div class="chip-row" aria-label={`${project.title} stack`}>
           {project.technologies.map((tech) => (
             <span class="tech-chip">{tech}</span>
           ))}
         </div>
-        {Array.isArray(project.description) ? (
-          <ul>
-            {project.description.map((desc) => (
-              <li>{desc}</li>
-            ))}
-          </ul>
-        ) : (
-          <p>{project.description}</p>
-        )}
+        <p>{project.description}</p>
         <div class="card-actions">
           <a class="dev-button" href={project.ctaLink} target="_blank" rel="noopener noreferrer">{project.ctaText}</a>
         </div>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -11,12 +11,7 @@ export const projects = [
 		title: "mendr",
 		date: "2026 June 28",
 		techStack: "TypeScript • Node.js • GitHub CLI • Vitest",
-		description: [
-			"Built an autonomous PR code-review CLI that orchestrates Codex or Claude Code workers through local subscriptions without collecting provider API keys.",
-			"Designed a deterministic review, fix, and validation loop that can scan a pull request, push targeted fixes, and repeat until the PR is clean or the round cap is reached.",
-			"Implemented file-backed daemon state so users can close the original terminal, list active reviews, and inspect progress from the CLI.",
-			"Added structured final report generation that posts one concise pull request summary instead of scattering review noise across the PR.",
-		],
+		description: "mendr keeps pull request review moving after you leave the terminal. Point it at a PR and it coordinates short-lived Codex or Claude Code workers to find scoped issues, apply and validate fixes, and repeat until the review is clean or reaches its round limit. Progress stays inspectable from the CLI, and the finished run lands as one focused PR report.",
 		ctaText: "View Project",
 		ctaLink: "https://github.com/Pepps233/mendr",
 		icon: GitIcon
@@ -25,12 +20,7 @@ export const projects = [
 		title: "ThinkGraph",
 		date: "2026 March 20",
 		techStack: "Next.js • FastAPI • React Flow • PostgreSQL • Celery",
-		description: [
-			"Built an AI research-paper workspace that turns arXiv links or uploaded PDFs into interactive knowledge graphs.",
-			"Implemented a FastAPI extraction pipeline that parses paper content, identifies entities and relationships, and stores graph-ready outputs.",
-			"Created a Next.js graph viewer with zooming, panning, expandable nodes, source provenance, and node detail panels for paper exploration.",
-			"Added async job processing with Celery and Redis so ingestion can stream progress while longer PDF and graph tasks run in the background.",
-		],
+		description: "ThinkGraph turns a dense research paper into a map you can explore. Add an arXiv link or PDF to trace concepts, methods, citations, equations, and reasoning through an interactive knowledge graph, with every node linked back to its source. Graph-aware chat, citation expansion, and multi-paper comparison make it easier to follow an idea across a paper and beyond it.",
 		ctaText: "View Project",
 		ctaLink: "https://github.com/Pepps233/think-graph",
 		icon: PostgresIcon
@@ -39,12 +29,7 @@ export const projects = [
 		title: "Opiral",
 		date: "2026 March 16",
 		techStack: "Next.js • FastAPI • Supabase • Pinecone • OpenAI",
-		description: [
-			"Built a Purdue research-lab matching app that parses student resumes and recommends labs aligned with skills, coursework, research, and projects.",
-			"Used GPT-4o resume extraction with OpenAI embeddings and Pinecone vector search to rank relevant labs from a curated Purdue dataset.",
-			"Generated personalized outreach email openings for each match while keeping the flow login-free and guarded by per-session rate limits.",
-			"Deployed a split frontend and backend architecture with Vercel, FastAPI, Supabase, Pinecone, and Upstash Redis.",
-		],
+		description: "Opiral helps Purdue students find research labs that fit what they already know and what they want to explore. A single resume upload becomes a ranked set of matches across 35+ curated labs, grounded in skills, coursework, research, and projects. Each result also includes a personalized email opening, so students can move from discovery to outreach without creating an account.",
 		ctaText: "View Project",
 		ctaLink: "https://www.opiral.com/",
 		icon: SupabaseIcon
@@ -53,26 +38,16 @@ export const projects = [
 		title: "Embed",
 		date: "2026 February 14",
 		techStack: "React • Vite • FastAPI • IndexedDB • Supabase",
-		description: [
-			"Built a browser-based knowledge companion for highlighting, annotating, and asking questions about web pages and PDFs.",
-			"Implemented a Manifest V3 extension with React, Vite, PDF.js, and local-first IndexedDB storage through Dexie.",
-			"Designed a hybrid local-cloud architecture that keeps annotations available offline while supporting vector search and LLM-powered answers through a FastAPI backend.",
-			"Added typed shared schemas, backend API boundaries, and separate CI checks for the extension and service layers.",
-		],
+		description: "Embed keeps reading, annotation, and questions in the same browser workflow. Highlight a web page or PDF, attach notes, and return to them even while offline through local-first storage. Optional cloud sync, semantic search, and LLM answers add deeper recall without making the core reading experience depend on a connection.",
 		ctaText: "View Project",
-		ctaLink: "https://github.com/Pepps233/embed-ai",
+		ctaLink: "https://github.com/Pepps233/embed",
 		icon: SupabaseIcon
 	},
 	{
 		title: "Overlay Studio",
 		date: "2026 January 7",
 		techStack: "Next.js • React • TypeScript • Tailwind CSS • Supabase",
-		description: [
-			"Built a LinkedIn banner generator with a drag-and-drop canvas for composing custom backgrounds, overlays, and accessories.",
-			"Implemented upload, layer management, resizing, rotation, aspect-ratio locking, and real-time preview controls for banner editing.",
-			"Added PNG and JPEG export options so users can download finished 1584 by 396 banner assets directly from the browser.",
-			"Integrated optional Supabase analytics while keeping the editor usable as a client-first creative tool.",
-		],
+		description: "Overlay Studio is a playful canvas for making LinkedIn banners feel personal. Mix built-in backgrounds, animal overlays, accessories, and your own images with drag-and-drop positioning, layer controls, smart snapping, and live preview. Finished 1584 by 396 designs export directly to PNG or JPEG, with no design software required.",
 		ctaText: "View Project",
 		ctaLink: "https://pepps233.github.io/OverlayStudio/",
 		icon: TailwindIcon
@@ -81,14 +56,7 @@ export const projects = [
 		title: "Barcode scanning Attendance Tracker",
 		date: "2024 August",
 		techStack: "OpenCV • Python • Pandas • Openpyxl",
-		description: [
-            "Designed and developed a barcode scanning sign-in/out system using Python, OpenCV, and Pyzbar to track attendance for a 35–40 member robotics team.",
-            "Automated attendance logging into Excel spreadsheets with Pandas and OpenPyXL, including sign-in, sign-out, and hours calculation per student.",
-            "Built a time-tracking module to calculate session durations and accumulated hours per student.",
-            "Implemented real-time performance monitoring (CPU/memory usage) with psutil for system reliability during continuous use.",
-            "Enhanced user experience with audio feedback on successful or failed scans and real-time webcam display of scanned results.",
-            "Delivered a low-cost, efficient alternative to manual attendance tracking, reducing errors and improving student accountability.",
-		],
+		description: "The Attendance Tracker gives a 35 to 40 member robotics team a quick barcode-based sign-in desk instead of a paper log. A webcam scan records arrival and departure, calculates each student’s session and cumulative hours, and writes the results to an Excel workbook. Live camera feedback, audio cues, and system monitoring keep the kiosk clear and dependable during long team sessions.",
 		ctaText: "View Project",
 		ctaLink: "https://github.com/Pepps233/2204-Attendance-",
 		icon: PythonIcon
@@ -97,12 +65,7 @@ export const projects = [
 		title: "Real-time American Sign Language (ASL) Alphabet Translator",
 		date: "2024 December",
 		techStack: "OpenCV • TensorFlow • MediaPipe • pyttsx3",
-        description: [
-            "Built a real-time ASL translation system using Python, OpenCV, and cvzone to detect hand gestures and classify them into ASL letters.",
-            "Integrated a Keras deep learning model to achieve accurate classification of alphabet signs from live webcam input.",
-            "Implemented image preprocessing techniques (cropping, resizing, normalization) to improve model performance under varying lighting and angles.",
-            "Added text-to-speech functionality (pyttsx3) to convert recognized signs into spoken language for seamless communication.",
-        ],
+		description: "The ASL Alphabet Translator turns live hand signs into a message you can see and hear. It recognizes alphabet gestures through the webcam, lets the signer add or remove letters as a phrase takes shape, and reads the completed text aloud. Simple keyboard controls keep composing, clearing, and speaking the message close at hand.",
 		ctaText: "View Project",
 		ctaLink: "https://github.com/Pepps233/Sign-Language-Translator",
 		icon: PythonIcon
@@ -111,13 +74,7 @@ export const projects = [
 		title: "Employee-Management API (Backend)",
 		date: "2025 August",
 		techStack: "Spring Boot • Java • Spring Data JPA • Docker • PostgreSQL",
-        description: [
-            "Developed a RESTful backend service using Java, Spring Boot, and PostgreSQL to manage employee data with CRUD functions.",
-            "Containerized the PostgreSQL database with Docker, simplifying setup and improving deployment consistency.",
-            "Integrated Spring Data JPA/Hibernate for seamless persistence, automatic schema updates, and efficient query handling.",
-            "Addressed the challenge of unreliable manual employee record management by providing a scalable, automated solution with reliable database-backed APIs.",
-            "Implemented a layered architecture (Controller → Service → Repository) with DTO mapping to ensure clean separation of concerns and maintainable code.",
-        ],
+		description: "The Employee Management API gives teams a predictable home for employee records. Its REST endpoints cover the complete record lifecycle, from adding and finding employees to updating details and removing outdated entries. PostgreSQL persistence and clear error responses keep integrations consistent, while a containerized database makes the service straightforward to run anywhere.",
 		ctaText: "View Project",
 		ctaLink: "https://github.com/Pepps233/Employee-Management-System",
 		icon: N8nIcon

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,82 +1,122 @@
-import GitIcon from '../assets/logos/Git-logo.svg?raw';
-import N8nIcon from '../assets/logos/N8n-logo.svg?raw';
-import PostgresIcon from '../assets/logos/Postgres-logo.svg?raw';
-import SupabaseIcon from '../assets/logos/Supabase-logo.svg?raw';
-import PythonIcon from '../assets/logos/Python-logo.svg?raw';
-import TailwindIcon from '../assets/logos/Tailwind-logo.svg?raw';
+type LiquidSymbol = "mendr" | "graph" | "spiral" | "embed" | "overlay" | "attendance" | "asl" | "people";
 
+interface Project {
+	title: string;
+	date?: string;
+	techStack: string;
+	mark: {
+		symbol: LiquidSymbol;
+		colors: [string, string, string];
+		seed: number;
+	};
+	description: string;
+	ctaText: string;
+	ctaLink: string;
+}
 
-export const projects = [
+export const projects: Project[] = [
 	{
 		title: "mendr",
 		date: "2026 June 28",
 		techStack: "TypeScript • Node.js • GitHub CLI • Vitest",
+		mark: {
+			symbol: "mendr",
+			colors: ["#ff5f6d", "#ffc371", "#8b5cf6"],
+			seed: 1,
+		},
 		description: "mendr keeps pull request review moving after you leave the terminal. Point it at a PR and it coordinates short-lived Codex or Claude Code workers to find scoped issues, apply and validate fixes, and repeat until the review is clean or reaches its round limit. Progress stays inspectable from the CLI, and the finished run lands as one focused PR report.",
 		ctaText: "View Project",
 		ctaLink: "https://github.com/Pepps233/mendr",
-		icon: GitIcon
 	},
 	{
 		title: "ThinkGraph",
 		date: "2026 March 20",
 		techStack: "Next.js • FastAPI • React Flow • PostgreSQL • Celery",
+		mark: {
+			symbol: "graph",
+			colors: ["#00c6ff", "#667eea", "#84fab0"],
+			seed: 2,
+		},
 		description: "ThinkGraph turns a dense research paper into a map you can explore. Add an arXiv link or PDF to trace concepts, methods, citations, equations, and reasoning through an interactive knowledge graph, with every node linked back to its source. Graph-aware chat, citation expansion, and multi-paper comparison make it easier to follow an idea across a paper and beyond it.",
 		ctaText: "View Project",
 		ctaLink: "https://github.com/Pepps233/think-graph",
-		icon: PostgresIcon
 	},
 	{
 		title: "Opiral",
 		date: "2026 March 16",
 		techStack: "Next.js • FastAPI • Supabase • Pinecone • OpenAI",
+		mark: {
+			symbol: "spiral",
+			colors: ["#ff4ecd", "#ff7b54", "#7f5af0"],
+			seed: 3,
+		},
 		description: "Opiral helps Purdue students find research labs that fit what they already know and what they want to explore. A single resume upload becomes a ranked set of matches across 35+ curated labs, grounded in skills, coursework, research, and projects. Each result also includes a personalized email opening, so students can move from discovery to outreach without creating an account.",
 		ctaText: "View Project",
 		ctaLink: "https://www.opiral.com/",
-		icon: SupabaseIcon
 	},
 	{
 		title: "Embed",
 		date: "2026 February 14",
 		techStack: "React • Vite • FastAPI • IndexedDB • Supabase",
+		mark: {
+			symbol: "embed",
+			colors: ["#2563eb", "#22d3ee", "#6ee7b7"],
+			seed: 4,
+		},
 		description: "Embed keeps reading, annotation, and questions in the same browser workflow. Highlight a web page or PDF, attach notes, and return to them even while offline through local-first storage. Optional cloud sync, semantic search, and LLM answers add deeper recall without making the core reading experience depend on a connection.",
 		ctaText: "View Project",
 		ctaLink: "https://github.com/Pepps233/embed",
-		icon: SupabaseIcon
 	},
 	{
 		title: "Overlay Studio",
 		date: "2026 January 7",
 		techStack: "Next.js • React • TypeScript • Tailwind CSS • Supabase",
+		mark: {
+			symbol: "overlay",
+			colors: ["#f857a6", "#ffb347", "#ff5e62"],
+			seed: 5,
+		},
 		description: "Overlay Studio is a playful canvas for making LinkedIn banners feel personal. Mix built-in backgrounds, animal overlays, accessories, and your own images with drag-and-drop positioning, layer controls, smart snapping, and live preview. Finished 1584 by 396 designs export directly to PNG or JPEG, with no design software required.",
 		ctaText: "View Project",
 		ctaLink: "https://pepps233.github.io/OverlayStudio/",
-		icon: TailwindIcon
 	},
 	{
-		title: "Barcode scanning Attendance Tracker",
+		title: "Attendance Tracker",
 		date: "2024 August",
 		techStack: "OpenCV • Python • Pandas • Openpyxl",
+		mark: {
+			symbol: "attendance",
+			colors: ["#ff8a00", "#ffd200", "#38d996"],
+			seed: 6,
+		},
 		description: "The Attendance Tracker gives a 35 to 40 member robotics team a quick barcode-based sign-in desk instead of a paper log. A webcam scan records arrival and departure, calculates each student’s session and cumulative hours, and writes the results to an Excel workbook. Live camera feedback, audio cues, and system monitoring keep the kiosk clear and dependable during long team sessions.",
 		ctaText: "View Project",
 		ctaLink: "https://github.com/Pepps233/2204-Attendance-",
-		icon: PythonIcon
 	},
 	{
-		title: "Real-time American Sign Language (ASL) Alphabet Translator",
+		title: "ASL Alphabet Translator",
 		date: "2024 December",
 		techStack: "OpenCV • TensorFlow • MediaPipe • pyttsx3",
+		mark: {
+			symbol: "asl",
+			colors: ["#8b5cf6", "#ec4899", "#38bdf8"],
+			seed: 7,
+		},
 		description: "The ASL Alphabet Translator turns live hand signs into a message you can see and hear. It recognizes alphabet gestures through the webcam, lets the signer add or remove letters as a phrase takes shape, and reads the completed text aloud. Simple keyboard controls keep composing, clearing, and speaking the message close at hand.",
 		ctaText: "View Project",
 		ctaLink: "https://github.com/Pepps233/Sign-Language-Translator",
-		icon: PythonIcon
 	},
 	{
-		title: "Employee-Management API (Backend)",
+		title: "Employee Management API",
 		date: "2025 August",
 		techStack: "Spring Boot • Java • Spring Data JPA • Docker • PostgreSQL",
+		mark: {
+			symbol: "people",
+			colors: ["#00b09b", "#96c93d", "#20bdff"],
+			seed: 8,
+		},
 		description: "The Employee Management API gives teams a predictable home for employee records. Its REST endpoints cover the complete record lifecycle, from adding and finding employees to updating details and removing outdated entries. PostgreSQL persistence and clear error responses keep integrations consistent, while a containerized database makes the service straightforward to run anywhere.",
 		ctaText: "View Project",
 		ctaLink: "https://github.com/Pepps233/Employee-Management-System",
-		icon: N8nIcon
 	},
 ];


### PR DESCRIPTION
## Summary

- Replace borrowed technology logos with eight original liquid-style product marks, each with its own palette and symbol
- Add ambient blob motion and pointer repulsion that makes the artwork react as if the cursor is pushing liquid
- Respect reduced-motion preferences and pause offscreen animation work
- Rewrite every project description around the product experience and user value, based on the source repositories
- Correct the Embed repository link and simplify longer project names

## Validation

- `npm run build`
- Verified `/projects/` returns HTTP 200 from the local Astro server
- Verified all 8 project cards and 32 liquid blob layers render in the generated page
- Verified the production output includes one shared interaction script for all marks